### PR TITLE
Add hostsfile entries from pillar

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,9 +17,23 @@ Available states
 ``hostsfile``
 -------
 
-Uses the `Salt Mine <http://docs.saltstack.com/topics/mine/>`_ function ``network.ip_addrs`` to add minion ids and their regarding ips to the local hosts file.
+The default behavior is to add entries to
+the hostsfile based on addresses collected
+via the `Salt Mine`_ function ``network.ip_addrs``.
+This will map minion ids and their regarding 
+IPs to the local hosts file.
 
-At a minimum, you must enable the network.ip_addrs function in pillar or in ``/etc/salt/minion``::
+.. _Salt Mine: http://docs.saltstack.com/topics/mine/
+
+To disable this set ``pillar['hostsfile:sources']``
+to a list excluding the member ``'mine'``.
+To only use the state ``hostsfile.static``
+set ``pillar['hostsfile:sources']`` to
+``['pillar]``.
+
+For the default `Salt Mine`_ based approach to 
+work you must enable the ``network.ip_addrs`` 
+function in pillar or in ``/etc/salt/minion``::
 
     mine_functions:
       network.ip_addrs: []

--- a/README.rst
+++ b/README.rst
@@ -48,3 +48,20 @@ If you are already using network.ip_addrs for something else (perhaps another st
 Also set and persist the hostname (again - using the minion id). This has so far been most useful on EC2 instances.
 
 Works on RedHat/CentOS 5.X or RedHat/CentOS 6.X and Amazon OS - should also work on Ubuntu/Debian.
+
+``hostsfile.static``
+--------------------
+
+Reads IP assignments from the pillar key
+``hostsfile:static_entries``. The format
+is a mapping from one IP address to a list
+of names::
+
+    hostsfile:
+        static_entries:
+            8.8.8.8:
+                - dns.google.com
+            198.58.116.50:
+                - www.saltstack.com
+                - saltstack.com
+               

--- a/hostsfile/init.sls
+++ b/hostsfile/init.sls
@@ -1,3 +1,11 @@
+{% set sources = salt['pillar.get'](
+    'hostsfile:sources', ['mine']) %}
+{%- if 'pillar' in sources %}
+include:
+    - hostsfile.static
+{%- endif %}
+
+{%- if 'mine' in sources %}
 # populate /etc/hosts with names and IP entries from your salt cluster
 # the minion id has to be the fqdn for this to work
 
@@ -22,4 +30,5 @@
       - {{ name }}
 {% endfor %}
 
+{% endif %}
 {% endif %}

--- a/hostsfile/static.sls
+++ b/hostsfile/static.sls
@@ -1,0 +1,14 @@
+# populate /etc/hosts with names and IP entries from pillar
+{%- set addrs = salt['pillar.get'](
+        'hostsfile:static_entries', {}) %}
+{%- if addrs %}
+    {%- for addr, names in addrs.items() %}
+{{ names|first }}_static-host-entry:
+  host.present:
+    - ip: {{ addr }}
+    - names:
+        {%- for name in names %}
+      - {{ name }}
+        {%- endfor %}
+    {% endfor %}
+{% endif %}


### PR DESCRIPTION
Added options to add static entries from pillar.

Also a pillar key `hostsfile:sources` to choose
from which sources (mine, pillar) to use data.
Defaults to 'mine', of course, so backward compatibility 
is provided.
