### PR TITLE
Allow specifying minions to be included in hosts

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ The formula works best if the minion id is the fqdn and (if the machines have mo
         - eth1
     mine_interval: 2
 
-If you are already using network.ip_addrs for something else (perhaps another state that wants information on a different interface than hostsfile should use), you can specify a mine alias in pillar to query instead:
+If you are already using network.ip_addrs for something else (perhaps another state that wants information on a different interface than hostsfile should use), you can specify a mine alias in pillar to query instead::
 
     hostsfile:
       alias: hostsfile_interface
@@ -41,6 +41,11 @@ If you are already using network.ip_addrs for something else (perhaps another st
       hostsfile_interface:
         mine_function: network.ip_addrs
         iface: eth0
+
+By default all minions in mine are added to the hosts file, but that can be overridden too::
+
+    hostsfile:
+      filter: '*-thisdatacenter-something'
 
 ``hostsfile.hostname``
 --------------

--- a/hostsfile/init.sls
+++ b/hostsfile/init.sls
@@ -10,7 +10,9 @@
 #  mine_interval: 2
 
 {%- set minealias = salt['pillar.get']('hostsfile:alias', 'network.ip_addrs') %}
-{%- set addrs = salt['mine.get']('*', minealias) %}
+{%- set minion_filter = salt['pillar.get']('hostsfile:filter', '*') %}
+
+{%- set addrs = salt['mine.get'](minion_filter, minealias) %}
 
 {%- if addrs is defined %}
 


### PR DESCRIPTION
This is helpful if you have a ton of minions but only actually need
"minions in the current datacenter" or "minions in my own DB cluster" or
whatever.

(I also fixed a readme typo while updating it)