### PR TITLE
Allow explicit host entries in pillar.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,14 @@ If you are already using network.ip_addrs for something else (perhaps another st
 By default all minions in mine are added to the hosts file, but that can be overridden too::
 
     hostsfile:
-      filter: '*-thisdatacenter-something'
+      minions: '*-thisdatacenter-something'
+
+And you can add explicit entries for non-mine hosts as well::
+
+    hostsfile:
+      hosts:
+        server1: 10.10.10.10
+        server2: 10.10.10.11
 
 ``hostsfile.hostname``
 --------------

--- a/hostsfile/init.sls
+++ b/hostsfile/init.sls
@@ -11,12 +11,13 @@
 
 {%- set minealias = salt['pillar.get']('hostsfile:alias', 'network.ip_addrs') %}
 {%- set minions = salt['pillar.get']('hostsfile:minions', '*') %}
-{%- set hosts = salt['pillar.get']('hostsfile:hosts', {}) %}
-
-{%- set addrs = salt['mine.get'](minions, minealias) %}
-{%- if addrs is defined %}
-{%- do hosts.update(addrs) %}
+{%- set hosts = {} %}
+{%- set pillar_hosts = salt['pillar.get']('hostsfile:hosts', {}) %}
+{%- set mine_hosts = salt['mine.get'](minions, minealias) %}
+{%- if mine_hosts is defined %}
+{%-   do hosts.update(mine_hosts) %}
 {%- endif %}
+{%- do hosts.update(pillar_hosts) %}
 
 {%- for name, addrlist in hosts.items() %}
 {{ name }}-host-entry:

--- a/hostsfile/init.sls
+++ b/hostsfile/init.sls
@@ -10,13 +10,15 @@
 #  mine_interval: 2
 
 {%- set minealias = salt['pillar.get']('hostsfile:alias', 'network.ip_addrs') %}
-{%- set minion_filter = salt['pillar.get']('hostsfile:filter', '*') %}
+{%- set minions = salt['pillar.get']('hostsfile:minions', '*') %}
+{%- set hosts = salt['pillar.get']('hostsfile:hosts', {}) %}
 
-{%- set addrs = salt['mine.get'](minion_filter, minealias) %}
-
+{%- set addrs = salt['mine.get'](minions, minealias) %}
 {%- if addrs is defined %}
+{%- do hosts.update(addrs) %}
+{%- endif %}
 
-{%- for name, addrlist in addrs.items() %}
+{%- for name, addrlist in hosts.items() %}
 {{ name }}-host-entry:
   host.present:
 {% if addrlist is string %}
@@ -27,5 +29,3 @@
     - names:
       - {{ name }}
 {% endfor %}
-
-{% endif %}


### PR DESCRIPTION
This is useful for distributing names that are not in mine for whatever
reason (e.g. external dependencies).

This also changes the name of the hostsfile:filter subkey to hostsfile:minions, which I think is more intuitive relative to what this PR adds. My previous PR got merged before I was done updating it (I didn't think about the difference until after putting it in). I doubt anyone's written anything depending on it yet so I don't think the change will break anything.