### PR TITLE
Small fixes to set-fqdn state

### DIFF
--- a/hostsfile/hostname.sls
+++ b/hostsfile/hostname.sls
@@ -34,4 +34,4 @@ set-fqdn:
     {% else %}
     - name: hostname {{ fqdn }}
     {% endif %}
-    - unless: test "{{ fqdn }}" == "$(hostname)"
+    - unless: test "{{ fqdn }}" = "$(hostname)"

--- a/hostsfile/hostname.sls
+++ b/hostsfile/hostname.sls
@@ -29,5 +29,9 @@ etc-sysconfig-network:
 
 set-fqdn:
   cmd.run:
+    {% if grains["init"] == "systemd" %}
+    - name: hostnamectl set-hostname {{ fqdn }}
+    {% else %}
     - name: hostname {{ fqdn }}
+    {% endif %}
     - unless: test "{{ fqdn }}" == "$(hostname)"


### PR DESCRIPTION
Make it work on systemd systems (tested on Debian 8.2) and fix unless condition so it does not trigger all the time.