### PR TITLE
support the host without rules,

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,6 +47,12 @@ By default all minions in mine are added to the hosts file, but that can be over
     hostsfile:
       minions: '*-thisdatacenter-something'
 
+By default specified minions in mine are added to the hosts file::
+
+    hostsfile:
+      minions: 'zk[1-5] and kafka[1-5]'
+      type: 'compound'
+
 And you can add explicit entries for non-mine hosts as well::
 
     hostsfile:

--- a/hostsfile/init.sls
+++ b/hostsfile/init.sls
@@ -11,9 +11,10 @@
 
 {%- set minealias = salt['pillar.get']('hostsfile:alias', 'network.ip_addrs') %}
 {%- set minions = salt['pillar.get']('hostsfile:minions', '*') %}
+{%- set minions_type = salt['pillar.get']('hostsfile:type', 'glob')%}
 {%- set hosts = {} %}
 {%- set pillar_hosts = salt['pillar.get']('hostsfile:hosts', {}) %}
-{%- set mine_hosts = salt['mine.get'](minions, minealias) %}
+{%- set mine_hosts = salt['mine.get'](minions, minealias, expr_form=minions_type) %}
 {%- if mine_hosts is defined %}
 {%-   do hosts.update(mine_hosts) %}
 {%- endif %}


### PR DESCRIPTION
such as only performed on zk\* and kafka\* minions, nginx\* will not bind the host
