### PR TITLE
Short hostname, not FQDN, for Debian and Ubuntu

### DIFF
--- a/hostsfile/hostname.sls
+++ b/hostsfile/hostname.sls
@@ -2,36 +2,42 @@
 # To match the hostname with the entries created by the hostsfile state, also execute this state.
 
 {%- set fqdn = grains['id'] %}
+{%- if grains['os_family'] == 'Debian' %}
+  {% set hostname = fqdn.split('.')[0] %}
+{% else %}
+  {% set hostname = fqdn %}
+{% endif %}
+
 {%- if grains['os_family'] == 'RedHat' %}
 
 etc-sysconfig-network:
   cmd.run:
-    - name: echo -e "NETWORKING=yes\nHOSTNAME={{ fqdn }}\n" > /etc/sysconfig/network
+    - name: echo -e "NETWORKING=yes\nHOSTNAME={{ hostname }}\n" > /etc/sysconfig/network
     - unless: test -f /etc/sysconfig/network
   file.replace:
     - name: /etc/sysconfig/network
     - pattern: HOSTNAME=localhost.localdomain
-    - repl: HOSTNAME={{ fqdn }}
+    - repl: HOSTNAME={{ hostname }}
 
 {% endif %}
 
 {%- if grains['os_family'] == 'Suse' %}
 /etc/HOSTNAME:
   file.managed:
-    - contents: {{ fqdn }}
+    - contents: {{ hostname }}
     - backup: false
 {% else %}
 /etc/hostname:
   file.managed:
-    - contents: {{ fqdn }}
+    - contents: {{ hostname }}
     - backup: false
 {% endif %}
 
 set-fqdn:
   cmd.run:
     {% if grains["init"] == "systemd" %}
-    - name: hostnamectl set-hostname {{ fqdn }}
+    - name: hostnamectl set-hostname {{ hostname }}
     {% else %}
-    - name: hostname {{ fqdn }}
+    - name: hostname {{ hostname }}
     {% endif %}
-    - unless: test "{{ fqdn }}" = "$(hostname)"
+    - unless: test "{{ hostname }}" = "$(hostname)"


### PR DESCRIPTION
Debian/Ubuntu use a short hostname, not the FQDN.  References below:

https://www.debian.org/doc/manuals/debian-reference/ch03.en.html#_the_hostname

> The kernel maintains the system hostname. The init script in runlevel S which
> is symlinked to "/etc/init.d/hostname.sh" sets the system hostname at boot
> time (using the hostname command) to the name stored in **"/etc/hostname".
> This file should contain only the system hostname, not a fully qualified
> domain name.**

http://manpages.ubuntu.com/manpages/trusty/man1/hostname.1.html

> /etc/hostname  Historically  this file was supposed to only contain the
> hostname and not the full canonical FQDN.  Nowadays  most  software  is able
> to  cope with a full FQDN here. This file is read at boot time by the system
> initialization scripts to set the hostname.