### PR TITLE
configurable base domain from pillar

### DIFF
--- a/hostsfile/init.sls
+++ b/hostsfile/init.sls
@@ -20,6 +20,7 @@
 {%- endif %}
 {%- do hosts.update(pillar_hosts) %}
 
+{%- set domain = salt.pillar.get('hostsfile:domain', '') %}
 {%- for name, addrlist in hosts.items() %}
 {{ name }}-host-entry:
   host.present:
@@ -30,4 +31,7 @@
 {% endif %}
     - names:
       - {{ name }}
+  {%- if domain %}
+      - {{ name }}.{{ domain }}
+  {%- endif %}
 {% endfor %}

--- a/pillar.example
+++ b/pillar.example
@@ -1,0 +1,2 @@
+hostsfile:
+  domain: example.com


### PR DESCRIPTION
Allows for minion IDs that are not a FQDN.

Fixes #22.