### PR TITLE
trim back hostnames for IPs to only those given in pillar[hostsfile:only]

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -60,6 +60,25 @@ And you can add explicit entries for non-mine hosts as well::
         server1: 10.10.10.10
         server2: 10.10.10.11
 
+To reduce the hostnames for an IP to those given in pillar
+you can place them in ``pillar[hostsfile:only]``::
+
+    hostsfile:
+      only:
+        10.10.10.10:
+            - server1.my.domain
+            - server1
+        10.10.10.11:
+            - server2.my.domain
+            - server2
+
+To remove an IP from the hostsfile specify an empty list
+of hostnames::
+
+    hostsfile:
+        only:
+            127.0.1.1: []
+
 ``hostsfile.hostname``
 --------------
 

--- a/hostsfile/init.sls
+++ b/hostsfile/init.sls
@@ -14,6 +14,7 @@
 {%- set minions_type = salt['pillar.get']('hostsfile:type', 'glob')%}
 {%- set hosts = {} %}
 {%- set pillar_hosts = salt['pillar.get']('hostsfile:hosts', {}) %}
+{%- set pillar_only = salt['pillar.get']('hostsfile:only', {}) %}
 {%- set mine_hosts = salt['mine.get'](minions, minealias, expr_form=minions_type) %}
 {%- if mine_hosts is defined %}
 {%-   do hosts.update(mine_hosts) %}
@@ -34,4 +35,16 @@
   {%- if domain %}
       - {{ name }}.{{ domain }}
   {%- endif %}
+{% endfor %}
+
+{%- for ip, hostnames in pillar_only.items() %}
+{{ ip }}-host-entry:
+  host.only:
+    - name: {{ ip }}
+  {% if hostnames is string %}
+    - hostnames:
+      - {{ hostnames }}
+  {% else %}
+    - hostnames: {{ hostnames | json }}
+  {% endif %}
 {% endfor %}

--- a/pillar.example
+++ b/pillar.example
@@ -1,2 +1,10 @@
 hostsfile:
   domain: example.com
+  hosts:
+    dns.quad9.net: 9.9.9.9
+  only:
+    127.0.0.1:
+      - localhost
+      - localhost.localdomain
+    # Removes all entries for 127.0.1.1:
+    127.0.1.1: []


### PR DESCRIPTION
AFAICT there is no way to remove IPs from the hostsfile in this formula yet.
And also none to trim back superfluous hostnames for a given IP.

By using the [hosts.only state](https://docs.saltstack.com/en/latest/ref/states/all/salt.states.host.html#salt.states.host.only) we can both remove IPs from
the hostsfile and reduce the hostnames for a given IP to the ones listed
in `pillar[hostsfile:only]`.

An example:
```
hostsfile:
    hosts:
        my.host.my.domain: 192.0.2.45
    only:
        127.0.0.1: localhost
        127.0.1.1: []
```

Oh, and you also can set multiple hostnames for an IP properly (something I wanted since #12). 
So no `{ myhostname: 192.0.2.17, myhostname.localdomain: 192.0.2.17 }` silliness to add to your pillar.

If someone can come up with a better pillar key than `hostfile:only` I'm all for it.